### PR TITLE
Refresh homepage: updated content, multilingual profile, community and photo sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # spdrcd.github.io
-My Github Page
+
+Personal homepage and portfolio for **Chieh "Jack" Chen** — backend software engineer, Houston, TX.
+
+Live at **[chiehc.com](https://chiehc.com)**, served by GitHub Pages from the `master` branch.
+
+## What's here
+
+A single-page site covering:
+
+- **About** — background, languages, and how I got into backend work
+- **日本語 · 中文** — the same profile in Japanese and Traditional Chinese
+- **Skills & Tooling** — programming languages, backend architecture, workflow
+- **Resume** — education and professional experience
+- **Community & Leadership** — Houston Nihongo Kai, Code4YALL, TJCC Houston
+- **Beyond Work** — the non-engineering half
+- **Through the Lens** — travel photography
+
+## Stack
+
+Static HTML, no build step.
+
+| Piece | What it does |
+| --- | --- |
+| [Bootstrap 5.1](https://getbootstrap.com/) | Layout and utility classes (`css/styles.css`) |
+| [Boxicons](https://boxicons.com/) | Social icons in the header |
+| [Bootstrap Icons](https://icons.getbootstrap.com/) | Icon set |
+| GitHub Pages | Hosting, with `CNAME` pointing at chiehc.com |
+
+## Layout
+
+```
+.
+├── index.html      # the whole page
+├── CNAME           # custom domain for GitHub Pages
+├── assets/
+│   ├── photos/     # gallery images (1200px, ~150KB each)
+│   └── vendor/     # boxicons, bootstrap-icons
+├── css/            # styles.css (Bootstrap + theme overrides)
+└── js/             # scripts.js
+```
+
+## Running it locally
+
+No dependencies. Clone and serve the directory:
+
+```bash
+git clone https://github.com/spdrcd/spdrcd.github.io.git
+cd spdrcd.github.io
+python3 -m http.server 8000
+```
+
+Then open <http://localhost:8000>.
+
+Opening `index.html` directly in a browser also works, though relative asset paths behave more predictably over HTTP.
+
+## Deploying
+
+Push to `master`. GitHub Pages rebuilds automatically; changes are usually live within a minute.
+
+## Contact
+
+- **Web** — [chiehc.com](https://chiehc.com)
+- **LinkedIn** — [chiehjchen](https://www.linkedin.com/in/chiehjchen/)
+- **GitHub** — [@spdrcd](https://github.com/spdrcd)

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="Chieh Jack Chen - personal portfolio homepage" />
+        <meta name="description" content="Chieh 'Jack' Chen - backend software engineer (Go), Houston TX. Portfolio, resume, community work, and photography. Profile available in English, Japanese, and Chinese." />
+        <meta name="keywords" content="backend engineer, Golang, Go, gRPC, REST API, CI/CD, Houston, ソフトウェアエンジニア, バックエンド, 軟體工程師, 後端" />
         <meta name="author" content="Chieh-Chih Jack Chen" />
         <title>Chieh "Jack" Chen - Homepage</title>
         <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
@@ -12,29 +13,15 @@
         <!-- vendor css -->
         <link href="assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
         <link href="assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
-        
+
     </head>
     <body id="page-top">
-        <!-- Navigation-->
-        <!-- <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
-            <div class="container px-4">
-                <a class="navbar-brand" href="#page-top">Home</a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-                <div class="collapse navbar-collapse" id="navbarResponsive">
-                    <ul class="navbar-nav ms-auto">
-                        <li class="nav-item"><a class="nav-link" href="#about">Home</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#services">Services</a></li>
-                        <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
-                    </ul>
-                </div>
-            </div>
-        </nav> -->
         <!-- Header-->
         <header class="py-5 bg-image-full" style="background-image: url('assets/pro-background.jpg')">
             <div id="myheader" class="text-center my-5">
-                <img class="img-fluid rounded-circle mb-2" style="max-width:15%" src="assets/chieh-pro.png" alt="..." />
+                <img class="img-fluid rounded-circle mb-2" style="max-width:15%" src="assets/chieh-pro.png" alt="Chieh 'Jack' Chen" />
                 <h1 class="text-white fs-3 fw-bolder">Chieh "Jack" Chen</h1>
-                <p class="text-white mb-2 fw-normal">Software Developer</p>
+                <p class="text-white mb-2 fw-normal">Backend Software Engineer &middot; Go &middot; Houston, TX</p>
                 <div class="social-links">
                     <a href="https://www.instagram.com/chennibyo/" class="instagram"><i class="bx bxl-instagram"></i></a>
                     <a href="https://www.linkedin.com/in/chiehjchen/" class="linkedin"><i class="bx bxl-linkedin"></i></a>
@@ -42,6 +29,7 @@
                 </div>
             </div>
         </header>
+
         <!-- About section-->
         <section id="about">
             <div class="container px-1">
@@ -49,130 +37,344 @@
                     <div class="col-lg-9">
                         <h2 class="fst-italic">About Chieh 'Jack' Chen...</h2>
                         <br>
-                        <!-- <h2></h2> -->
-                        
-                        <p class="lead">I am a seasoned polyglot software engineer who embarked on my coding journey with a passion for gaming. In my professional realm, I specialize in Back-End software development, bringing with me a wealth of experience in crafting solutions with RESTful API and microservice architecture. Currently, my primary programming languages of choice are Golang and C#, though I adeptly navigate through others such as C++, Python, and Ruby.
+                        <p class="lead">I am a backend-focused software engineer who came to this field the long way around &mdash; a career change by way of a Master's in Computer Science. <a href="https://go.dev/">Go</a> has been my primary language for the better part of seven years; I reach for it because it stays lightweight and gets out of the way. I also write Python, JavaScript, C++, and Ruby when a problem calls for them, and I take documentation seriously enough to enjoy writing it.</p>
 
-                          Beyond the realm of coding, I am a self-taught Japanese speaker with a penchant for intellectual pursuits. When not immersed in the world of technology, I find joy in leisurely bike rides, relishing delectable experiences at quality Asian restaurants, and sharing moments of laughter with others.</p>
-                        <!-- <ul>
-                            <li>Clickable nav links that smooth scroll to page sections</li>
-                            <li>Responsive behavior when clicking nav links perfect for a one page website</li>
-                            <li>Bootstrap's scrollspy feature which highlights which section of the page you're on in the navbar</li>
-                            <li>Minimal custom CSS so you are free to explore your own unique design options</li>
-                        </ul> -->
+                        <p class="lead">Most of my work lives in the parts of a system users never see: debugging and bugfix work, CI/CD pipelines in GitHub Actions, RESTful and gRPC services, SQL and database CRUD operations, and the feature development that ties them together. I have built for oil and gas monitoring, security investigation tooling, and manufacturing execution systems &mdash; domains where being wrong is expensive and the data does not wait for you.</p>
+
+                        <p class="lead">I speak Mandarin Chinese, Japanese, and American English. Outside of work I run <a href="https://nihongokai.org">Houston Nihongo Kai</a>, a 501(c)(3) nonprofit that grew out of a Japanese language meetup. When I am not doing either of those things I am drawing, listening to house and trance, planning a trip to Japan or Taiwan, or hunting down good food &mdash; which, as far as I am concerned, is only as good as the company you eat it with.</p>
                     </div>
                 </div>
             </div>
         </section>
-        <!-- Services section-->
-        <!-- <section class="bg-light" id="services">
-            <div class="container px-1">
+
+        <!-- ======= Multilingual Profile Section ======= -->
+        <section id="profile-intl" class="bg-light">
+            <div class="container px-5">
+
+                <div class="section-title">
+                    <h2>日本語 &middot; 中文</h2>
+                    <p class="lead">A profile in Japanese and Chinese, for recruiters and teams who prefer to read it that way.</p>
+                </div>
+
                 <div class="row gx-4 justify-content-center">
-                    <div class="col-lg-9">
-                        <h2>Services we offer</h2>
-                        <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aut optio velit inventore, expedita quo laboriosam possimus ea consequatur vitae, doloribus consequuntur ex. Nemo assumenda laborum vel, labore ut velit dignissimos.</p>
+                    <div class="col-lg-5" lang="ja">
+                        <h3 class="resume-title">日本語プロフィール</h3>
+                        <div class="resume-item pb-0">
+                            <p>バックエンドを専門とするソフトウェアエンジニアとして、米国テキサス州ヒューストンを拠点に活動しています。主力言語は Go で、6年以上の実務経験があります。業務に応じて Python、JavaScript、C++、Ruby も使用します。</p>
+
+                            <p>得意分野は、RESTful API および gRPC マイクロサービスの設計と実装、SQL データベースのクエリと CRUD 操作、GitHub Actions を用いた CI/CD パイプラインの構築、そして不具合の調査・修正です。</p>
+
+                            <p>現在は Cisco Systems にてバックエンド開発を担当しています。以前は National Oilwell Varco の社内スタートアップで、石油・ガス業界向けの監視ソフトウェアを開発していました。時系列データの集計と PDF レポート生成、SMS・メール・ポータルへの通知機能、operations 向けスケジューラーツールなどを実装しています。</p>
+
+                            <p>コンピュータサイエンスの修士号を取得し、キャリアチェンジを経て現職に至ります。日本語・中国語（北京語）・英語のトリリンガルで、ヒューストンでは日本語コミュニティ「<a href="https://nihongokai.org">Houston Nihongo Kai</a>」（501(c)(3) 非営利団体）を運営しています。</p>
+                        </div>
+                    </div>
+
+                    <div class="col-lg-5" lang="zh-Hant">
+                        <h3 class="resume-title">中文簡介</h3>
+                        <div class="resume-item pb-0">
+                            <p>我是一名以後端為主的軟體工程師，目前定居於美國德州休士頓。主要使用 Go 語言，具備六年以上的實務經驗，同時也能依需求使用 Python、JavaScript、C++ 與 Ruby。</p>
+
+                            <p>專長包括 RESTful API 與 gRPC 微服務架構的設計與實作、SQL 資料庫查詢與 CRUD 操作、以 GitHub Actions 建置 CI/CD 流程，以及除錯與問題排查。</p>
+
+                            <p>目前任職於 Cisco Systems，負責後端開發。先前於 National Oilwell Varco 的內部新創團隊，開發石油與天然氣產業使用的監控軟體，工作內容涵蓋時序資料查詢、PDF 報表產生，以及簡訊、電子郵件與網頁入口的警報通知功能，並參與營運排程工具的開發。</p>
+
+                            <p>我擁有計算機科學碩士學位，是轉職後投入軟體開發領域。能流利使用中文、日文與英文，並在休士頓經營日語社群「<a href="https://nihongokai.org">Houston Nihongo Kai</a>」（501(c)(3) 非營利組織）。</p>
+                        </div>
                     </div>
                 </div>
+
             </div>
-        </section> -->
-        <!-- Contact section-->
-        <!-- <section id="contact">
-            <div class="container px-4">
+        </section><!-- End Multilingual Profile Section -->
+
+        <!-- ======= Skills Section ======= -->
+        <section id="skills">
+            <div class="container px-5">
+
+                <div class="section-title">
+                    <h2>Skills &amp; Tooling</h2>
+                </div>
+
                 <div class="row gx-4 justify-content-center">
-                    <div class="col-lg-8">
-                        <h2>Contact us</h2>
-                        <p class="lead">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Vero odio fugiat voluptatem dolor, provident officiis, id iusto! Obcaecati incidunt, qui nihil beatae magnam et repudiandae ipsa exercitationem, in, quo totam.</p>
+                    <div class="col-lg-5">
+                        <h3 class="resume-title">Languages</h3>
+                        <div class="resume-item pb-0">
+                            <ul>
+                                <li><strong>Go</strong> &mdash; primary language, 6+ years</li>
+                                <li>Python</li>
+                                <li>JavaScript</li>
+                                <li>C++</li>
+                                <li>Ruby</li>
+                                <li>SQL</li>
+                            </ul>
+                        </div>
+
+                        <h3 class="resume-title">Spoken Languages</h3>
+                        <div class="resume-item pb-0">
+                            <ul>
+                                <li>American English</li>
+                                <li>Mandarin Chinese &mdash; 中文</li>
+                                <li>Japanese &mdash; 日本語</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div class="col-lg-5">
+                        <h3 class="resume-title">Backend &amp; Architecture</h3>
+                        <div class="resume-item pb-0">
+                            <ul>
+                                <li>RESTful API design &mdash; GET / POST / PUT / DELETE</li>
+                                <li>gRPC microservice architecture</li>
+                                <li>GraphQL query support for front-end clients</li>
+                                <li>Relational databases, SQL queries and CRUD operations</li>
+                                <li>Time-series data querying and reporting</li>
+                                <li>Modbus TCP &mdash; industrial / MES integration</li>
+                            </ul>
+                        </div>
+
+                        <h3 class="resume-title">Workflow</h3>
+                        <div class="resume-item pb-0">
+                            <ul>
+                                <li>Git and GitHub version control workflow</li>
+                                <li>GitHub Actions CI/CD pipelines</li>
+                                <li>Debugging and bugfix work</li>
+                                <li>Markdown technical documentation</li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
+
             </div>
-        </section> -->
+        </section><!-- End Skills Section -->
 
-    <!-- ======= Resume Section ======= -->
-    <section id="resume" class="resume">
-        <div class="container px-5">
-  
-          <div class="section-title">
-            <h2>Resume</h2>
-            <p class="lead">I currently work as a Back-End Software Engineer, using <a href="https://go.dev/">Go</a> Programming Language for backend services.</p>
-          </div>
-  
-          <div class="row gx-4 justify-content-center">
-            <div class="col-lg-5">
-              <h3 class="resume-title">Summary</h3>
-              <div class="resume-item pb-0">
-                <h4>Chieh "Jack" Chen</h4>
-                <!-- <p><em>Innovative and deadline-driven Graphic Designer with 3+ years of experience designing and developing user-centered digital/print marketing material from initial concept to final, polished deliverable.</em></p> -->
-                <ul>
-                  <li>Houston, TX</li>
-                  <li>(832)738-2220</li>
-                  <li>me@chiehc.com</li>
-                </ul>
-              </div>
-  
-              <h3 class="resume-title">Education</h3>
-              <div class="resume-item">
-                <h4>Master of Science &amp; Computer Science</h4>
-                <h5>2015 - 2016</h5>
-                <p><em>University of Houston, Houston, TX</em></p>
-                <!-- <p>Qui deserunt veniam. Et sed aliquam labore tempore sed quisquam iusto autem sit. Ea vero voluptatum qui ut dignissimos deleniti nerada porti sand markend</p> -->
-              </div>
-              <div class="resume-item">
-                <h4>Bachelor of Arts &amp; Communications</h4>
-                <h5>208 - 2013</h5>
-                <p><em>University of Houston, Houston, TX</em></p>
-                <!-- <p>Quia nobis sequi est occaecati aut. Repudiandae et iusto quae reiciendis et quis Eius vel ratione eius unde vitae rerum voluptates asperiores voluptatem Earum molestiae consequatur neque etlon sader mart dila</p> -->
-              </div>
+        <!-- ======= Resume Section ======= -->
+        <section id="resume" class="resume">
+            <div class="container px-5">
+
+                <div class="section-title">
+                    <h2>Resume</h2>
+                    <p class="lead">I currently work as a Back-End Software Engineer, using <a href="https://go.dev/">Go</a> Programming Language for backend services.</p>
+                </div>
+
+                <div class="row gx-4 justify-content-center">
+                    <div class="col-lg-5">
+                        <h3 class="resume-title">Summary</h3>
+                        <div class="resume-item pb-0">
+                            <h4>Chieh "Jack" Chen</h4>
+                            <ul>
+                                <li>Houston, TX</li>
+                                <li>(832)738-2220</li>
+                                <li>me@chiehc.com</li>
+                            </ul>
+                        </div>
+
+                        <h3 class="resume-title">Education</h3>
+                        <div class="resume-item">
+                            <h4>Master of Science &amp; Computer Science</h4>
+                            <h5>2015 - 2016</h5>
+                            <p><em>University of Houston, Houston, TX</em></p>
+                        </div>
+                        <div class="resume-item">
+                            <h4>Bachelor of Arts &amp; Communications</h4>
+                            <h5>2008 - 2013</h5>
+                            <p><em>University of Houston, Houston, TX</em></p>
+                        </div>
+                    </div>
+                    <div class="col-lg-5">
+                        <h3 class="resume-title">Professional Experience</h3>
+                        <div class="resume-item">
+                            <h4>Software Engineer</h4>
+                            <h5>2022 - Present</h5>
+                            <p><em>Cisco Systems, Inc.</em></p>
+                            <ul>
+                                <li>Key implementer of the custom Python script feature for Secure Endpoint / XDR Orbital, allowing IT investigators to run their own scripts and pull valuable information from devices installed across an organization</li>
+                                <li>Collaborate with the front-end team on feature design and implementation, backing GraphQL queries with SQL database requests and server-side data manipulation</li>
+                                <li>Contribute across the backend service stack in Go, from feature development through debugging and release</li>
+                            </ul>
+                        </div>
+                        <div class="resume-item">
+                            <h4>Software Developer - BackEnd</h4>
+                            <h5>2018 - 2022</h5>
+                            <p><em>National Oilwell Varco, Houston, TX</em></p>
+                            <ul>
+                                <li>Built for an internal startup producing a monitoring software suite for the oil drilling field, used by fracking operators</li>
+                                <li>Queried time-series drilling data from the database and turned it into key summary reporting tools, generated as PDF reports</li>
+                                <li>Developed alerting tools delivering to SMS text message, email, and the customer web portal</li>
+                                <li>Key contributor to the scheduler tool used for oil and gas operations</li>
+                            </ul>
+                        </div>
+                        <div class="resume-item">
+                            <h4>Contract Programmer</h4>
+                            <h5>2017 - 2018</h5>
+                            <p><em>Towworks, Lake Jackson, TX</em></p>
+                            <ul>
+                                <li>Contract backend development work</li>
+                            </ul>
+                        </div>
+                        <div class="resume-item">
+                            <h4>Software Engineering Intern</h4>
+                            <p><em>Manufacturing &mdash; MES</em></p>
+                            <ul>
+                                <li>Worked on manufacturing execution system (MES) software, integrating equipment data over the Modbus TCP protocol</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
             </div>
-            <div class="col-lg-5">
-              <h3 class="resume-title">Professional Experience</h3>
-              <div class="resume-item">
-                <h4>Software Engineer</h4>
-                <h5>2022 - Present</h5>
-                <p><em>Cisco Systems, Inc.</em></p>
-                <ul>
-                  <!-- <li>Lead in the design, development, and implementation of the graphic, layout, and production communication materials</li>
-                  <li>Delegate tasks to the 7 members of the design team and provide counsel on all aspects of the project. </li>
-                  <li>Supervise the assessment of all graphic materials in order to ensure quality and accuracy of the design</li>
-                  <li>Oversee the efficient use of production project budgets ranging from $2,000 - $25,000</li> -->
-                </ul>
-              </div>
-              <div class="resume-item">
-                <h4>Software Developer - BackEnd</h4>
-                <h5>2018 - 2022</h5>
-                <p><em>National Oilwell Varco, Houston, TX </em></p>
-                <ul>
-                  <!-- <li>Lead in the design, development, and implementation of the graphic, layout, and production communication materials</li>
-                  <li>Delegate tasks to the 7 members of the design team and provide counsel on all aspects of the project. </li>
-                  <li>Supervise the assessment of all graphic materials in order to ensure quality and accuracy of the design</li>
-                  <li>Oversee the efficient use of production project budgets ranging from $2,000 - $25,000</li> -->
-                </ul>
-              </div>
-              <div class="resume-item">
-                <h4>Contract Programmer</h4>
-                <h5>2017 - 2018</h5>
-                <p><em>Towworks, Lackjackson, TX</em></p>
-                <ul>
-                  <!-- <li>Developed numerous marketing programs (logos, brochures,infographics, presentations, and advertisements).</li>
-                  <li>Managed up to 5 projects or tasks at a given time while under pressure</li>
-                  <li>Recommended and consulted with clients on the most appropriate graphic design</li>
-                  <li>Created 4+ design presentations and proposals a month for clients and account managers</li> -->
-                </ul>
-              </div>
+        </section><!-- End Resume Section -->
+
+        <!-- ======= Community Section ======= -->
+        <section id="community" class="bg-light">
+            <div class="container px-5">
+
+                <div class="section-title">
+                    <h2>Community &amp; Leadership</h2>
+                    <p class="lead">Work I do outside of work &mdash; building communities in Houston around language, technology, and showing up for each other.</p>
+                </div>
+
+                <div class="row gx-4 justify-content-center">
+                    <div class="col-lg-5">
+                        <h3 class="resume-title">Houston Nihongo Kai</h3>
+                        <div class="resume-item">
+                            <h4>Founder &amp; Organizer</h4>
+                            <p><em>501(c)(3) Nonprofit &mdash; <a href="https://nihongokai.org">nihongokai.org</a></em></p>
+                            <ul>
+                                <li>Grew a small Japanese language meetup into a registered 501(c)(3) nonprofit with raised funding and a growing, thriving membership</li>
+                                <li>Expanded well past language practice into a full calendar of recurring events: monthly social mixers, beginner Japanese grammar lessons, and Eikaiwa ESL lessons for Japanese people living in Houston</li>
+                                <li>Built partnerships across the city, including a collaborative picnic with the University of Houston Japanese club</li>
+                                <li>Organize group volunteering so the community gives back to Houston as well as to each other</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div class="col-lg-5">
+                        <h3 class="resume-title">Code4YALL</h3>
+                        <div class="resume-item">
+                            <h4>Ambassador</h4>
+                            <p><em>Houston programming meetup community</em></p>
+                            <ul>
+                                <li>Officially recognized as a key ambassador of the club by one of the founders</li>
+                                <li>Recruited speakers and shaped programming for presentations that were intriguing, fun, and genuinely engaging</li>
+                                <li>Presented as well, including a fireside chat on how to break into the tech industry</li>
+                            </ul>
+                        </div>
+
+                        <h3 class="resume-title">Taiwanese Junior Chamber of Commerce</h3>
+                        <div class="resume-item">
+                            <h4>Volunteer &mdash; Houston Chapter</h4>
+                            <ul>
+                                <li>Set up and ran their social media presence across Instagram, Threads, and Linktree</li>
+                                <li>Designed event flyers in Canva and handled ongoing WordPress website updates</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
             </div>
-          </div>
-  
-        </div>
-      </section><!-- End Resume Section -->
-  
-  
-      <section></section>
+        </section><!-- End Community Section -->
 
+        <!-- ======= Beyond Work Section ======= -->
+        <section id="interests">
+            <div class="container px-5">
 
+                <div class="section-title">
+                    <h2>Beyond Work</h2>
+                </div>
 
+                <div class="row gx-4 justify-content-center">
+                    <div class="col-lg-10">
+                        <p class="lead">I draw. I listen to a lot of EDM, house, and trance. I watch anime. I travel &mdash; Japan and Taiwan most often, and as much of the US as I can manage. Outdoors I am usually swimming, hiking, climbing something, or soaking in a hot spring afterward.</p>
+                        <p class="lead">Above all of it, though, I am a foodie. And what good is good food without good friends? I like to enjoy my friends' company just as much as the meal.</p>
+                    </div>
+                </div>
+
+            </div>
+        </section><!-- End Beyond Work Section -->
+
+        <!-- ======= Photography Section ======= -->
+        <style>
+            #gallery .photo-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+                gap: 12px;
+            }
+            #gallery .photo-grid figure {
+                margin: 0;
+                overflow: hidden;
+                border-radius: 6px;
+                background: #e9ecef;
+            }
+            #gallery .photo-grid img {
+                display: block;
+                width: 100%;
+                height: 260px;
+                object-fit: cover;
+                transition: transform .35s ease;
+            }
+            #gallery .photo-grid figure:hover img { transform: scale(1.04); }
+            #gallery .photo-grid figcaption {
+                font-size: .8rem;
+                color: #6c757d;
+                padding: .4rem .1rem 0;
+            }
+            @media (max-width: 575px) {
+                #gallery .photo-grid img { height: 200px; }
+            }
+        </style>
+        <section id="gallery" class="bg-light">
+            <div class="container px-5">
+
+                <div class="section-title">
+                    <h2>Through the Lens</h2>
+                    <p class="lead">Photos I took while travelling &mdash; Japan, Taiwan, and points in between.</p>
+                </div>
+
+                <div class="photo-grid">
+                    <figure>
+                        <img src="assets/photos/temple-approach.jpg" alt="Wooden bridge leading to a temple gate surrounded by green trees, Japan" loading="lazy" width="1200" height="900" />
+                        <figcaption>Temple approach, Japan</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/hydrangea-road.jpg" alt="Blue hydrangeas blooming along a narrow roadside path" loading="lazy" width="900" height="1200" />
+                        <figcaption>Hydrangea season</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/haneda-apron.jpg" alt="ANA and Garuda Indonesia aircraft on the apron at a Japanese airport" loading="lazy" width="1200" height="900" />
+                        <figcaption>On the apron</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/lantern-food-street.jpg" alt="Crowded food street under rows of red and orange paper lanterns" loading="lazy" width="900" height="1200" />
+                        <figcaption>Food street, under the lanterns</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/wish-ribbons.jpg" alt="A wall of red wish ribbons and prayer tablets surrounding a bronze bell" loading="lazy" width="1200" height="900" />
+                        <figcaption>Wall of wishes</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/taipei101-alley.jpg" alt="Taipei 101 framed in the gap between two apartment buildings" loading="lazy" width="900" height="1200" />
+                        <figcaption>Taipei 101, framed</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/taipei101-skyline.jpg" alt="Taipei skyline with Taipei 101 seen from a hillside" loading="lazy" width="1200" height="900" />
+                        <figcaption>Taipei from above</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/window-bars.jpg" alt="Taiwanese apartment blocks seen through vertical window bars" loading="lazy" width="900" height="1200" />
+                        <figcaption>Through the bars</figcaption>
+                    </figure>
+                    <figure>
+                        <img src="assets/photos/rail-construction.jpg" alt="Cranes and heavy equipment at a railway construction site beside a passing train" loading="lazy" width="1200" height="900" />
+                        <figcaption>Rail works in progress</figcaption>
+                    </figure>
+                </div>
+
+            </div>
+        </section><!-- End Photography Section -->
 
         <!-- Footer-->
         <footer class="py-5 bg-dark">
-            <div class="container px-4"><p class="m-0 text-center text-white">Copyright &copy; Chiehc.com 2022</p></div>
+            <div class="container px-4"><p class="m-0 text-center text-white">Copyright &copy; Chiehc.com 2026</p></div>
         </footer>
         <!-- Bootstrap core JS-->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
Refreshes `index.html` and `README.md`. Design and CSS are untouched — this reuses the existing Bootstrap classes (`section-title`, `resume-title`, `resume-item`, `bg-light`).

## What changed

### Content
- **About** — rewritten. Go as the primary language (6+ years), career change via MS in CS, three spoken languages, the domains actually worked in.
- **日本語 · 中文** *(new)* — the same professional profile in Japanese and Traditional Chinese, for JP/CN recruiters. Wrapped in `lang="ja"` / `lang="zh-Hant"` for correct font rendering and screen readers.
- **Skills & Tooling** *(new)* — programming languages, backend/architecture, workflow, spoken languages.
- **Resume** — the empty `<ul>` blocks under Cisco and NOV are now filled in. Added the MES/Modbus TCP internship.
- **Community & Leadership** *(new)* — Houston Nihongo Kai (501(c)(3)), Code4YALL, Taiwanese Junior Chamber of Commerce.
- **Beyond Work** *(new)* — drawing, music, travel, outdoors, food.
- **Through the Lens** *(new)* — 9-photo travel gallery, CSS grid, `loading="lazy"`, explicit `width`/`height` to avoid layout shift.

### Fixes
- Education year typo: `208 - 2013` → `2008 - 2013`
- `Lackjackson, TX` → `Lake Jackson, TX`
- Copyright `2022` → `2026`
- Removed ~60 lines of commented-out dead markup (nav, services, contact, lorem ipsum)
- Added `alt` text to the profile image (was `"..."`)
- Added a `keywords` meta tag with JP/CN terms

### README
Two lines → stack table, file layout, local preview steps, deploy notes.

## ⚠️ Before merging

**1. The gallery images are not in this branch yet.** `index.html` references nine files under `assets/photos/` that still need to be uploaded:

```
temple-approach.jpg      hydrangea-road.jpg     haneda-apron.jpg
lantern-food-street.jpg  wish-ribbons.jpg       taipei101-alley.jpg
taipei101-skyline.jpg    window-bars.jpg        rail-construction.jpg
```

They're resized to 1200px / ~150KB each (down from 5184px / ~10MB). **Merging before adding them will leave nine broken images on the live site.**

**2. Please verify these — they were inferred:**
- Job title **"Founder & Organizer"** at Houston Nihongo Kai
- The **MES internship** entry has no company name or dates
- **Towworks** has only a placeholder bullet
- Phone number and email remain publicly listed (unchanged from before, but worth a second look)
