### PR TITLE
Fix resume card spacing and reword "shipping" to avoid the freight reading

### DIFF
--- a/css/theme-modern.css
+++ b/css/theme-modern.css
@@ -3,6 +3,12 @@
  * Warm, cool-toned theme layer for chiehc.com.
  * Loaded AFTER css/styles.css so it overrides the base Bootstrap theme.
  * Remove the <link> tag in index.html to revert to the original look.
+ *
+ * Note on !important: the base theme styles these components with
+ * two-class selectors (.resume .resume-item h4), which outrank the
+ * single-class selectors here regardless of load order. Rather than
+ * edit styles.css, the handful of properties that genuinely conflict
+ * are forced. Everything else relies on normal cascade.
  */
 
 :root {
@@ -167,7 +173,10 @@ section.bg-light {
     background-color: var(--c-surface-alt) !important;
 }
 
-.section-title { margin-bottom: 2.25rem; }
+.section-title {
+    margin-bottom: 2rem !important;
+    padding-bottom: 0 !important;
+}
 
 .section-title h2 {
     position: relative;
@@ -198,6 +207,8 @@ section p.lead {
     line-height: 1.8;
     font-weight: 400;
 }
+
+.section-title p { margin-bottom: 0 !important; }
 
 #about h2.fst-italic {
     font-style: normal !important;
@@ -232,25 +243,30 @@ section a:hover {
     border-bottom-color: var(--c-accent);
 }
 
-/* ---------- Cards ---------- */
+/* ---------- Cards ----------
+   The base theme gives .resume-item a coloured left border and styles its
+   headings large, blue and uppercase. These rules replace that treatment. */
 
 .resume-title {
-    font-size: .8rem !important;
-    font-weight: 600;
+    font-size: .78rem !important;
+    font-weight: 600 !important;
     text-transform: uppercase;
     letter-spacing: .09em;
-    color: var(--c-accent);
-    margin: 1.75rem 0 .9rem;
+    color: var(--c-accent) !important;
+    margin: 1.6rem 0 .75rem !important;
 }
+
+.resume-title:first-child { margin-top: 0 !important; }
 
 .resume-item {
     position: relative;
-    background: var(--c-surface);
-    border: 1px solid var(--c-border);
-    border-radius: var(--c-radius);
+    background: var(--c-surface) !important;
+    border: 1px solid var(--c-border) !important;
+    border-left: 1px solid var(--c-border) !important;
+    border-radius: var(--c-radius) !important;
     box-shadow: var(--c-shadow);
-    padding: 1.15rem 1.3rem 1.15rem 1.4rem;
-    margin-bottom: 1rem;
+    padding: 1.15rem 1.3rem !important;
+    margin: 0 0 1rem !important;
     overflow: hidden;
     transition: transform .2s ease, box-shadow .2s ease;
 }
@@ -275,22 +291,32 @@ section a:hover {
 .resume-item:hover::before { opacity: 1; }
 
 .resume-item h4 {
-    font-size: 1.02rem;
-    font-weight: 600;
-    color: var(--c-text);
-    margin-bottom: .2rem;
+    font-size: 1.02rem !important;
+    font-weight: 600 !important;
+    color: var(--c-text) !important;
+    text-transform: none !important;
+    letter-spacing: -0.01em !important;
+    line-height: 1.35 !important;
+    margin: 0 0 .4rem !important;
 }
 
 .resume-item h5 {
     display: inline-block;
-    font-size: .75rem;
-    font-weight: 500;
-    color: var(--c-accent);
+    font-size: .75rem !important;
+    font-weight: 500 !important;
+    color: var(--c-accent) !important;
     background: var(--c-accent-soft);
-    padding: .18rem .6rem;
+    padding: .18rem .6rem !important;
     border-radius: 999px;
-    margin-bottom: .5rem;
+    margin: 0 0 .55rem !important;
 }
+
+.resume-item p {
+    margin: 0 0 .6rem !important;
+    line-height: 1.65;
+}
+
+.resume-item p:last-child { margin-bottom: 0 !important; }
 
 .resume-item p em {
     font-style: normal;
@@ -298,23 +324,23 @@ section a:hover {
     font-size: .875rem;
 }
 
-.resume-item p { margin-bottom: .6rem; }
-
 .resume-item ul {
-    padding-left: 1.05rem;
-    margin-bottom: 0;
+    padding-left: 1.1rem !important;
+    margin: 0 !important;
+    list-style: disc;
 }
 
-.resume-item li {
+.resume-item ul li {
     color: var(--c-text-soft);
     font-size: .93rem;
-    line-height: 1.7;
-    margin-bottom: .35rem;
+    line-height: 1.65;
+    padding: 0 !important;
+    margin: 0 0 .4rem !important;
 }
 
-.resume-item li::marker { color: var(--c-warm); }
+.resume-item ul li::marker { color: var(--c-warm); }
 
-.resume-item li:last-child { margin-bottom: 0; }
+.resume-item ul li:last-child { margin-bottom: 0 !important; }
 
 [lang="ja"] .resume-item p,
 [lang="zh-Hant"] .resume-item p {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="Chieh 'Jacky' Chen - backend software engineer, 8 years shipping production services, 6+ in Go. Houston, TX and open to remote. Profile in English, Japanese, and Chinese." />
+        <meta name="description" content="Chieh 'Jacky' Chen - backend software engineer, 8 years building and running production systems, 6+ in Go. Houston, TX and open to remote. Profile in English, Japanese, and Chinese." />
         <meta name="keywords" content="backend engineer, Golang, Go, gRPC, GraphQL, REST API, microservices, AWS, Kubernetes, CI/CD, Houston, ソフトウェアエンジニア, バックエンド, 軟體工程師, 後端" />
         <meta name="author" content="Chieh-Chih Jacky Chen" />
         <title>Chieh "Jacky" Chen - Backend Software Engineer</title>
@@ -59,7 +59,7 @@
                     <div class="col-lg-9">
                         <h2 class="fst-italic">About Chieh 'Jacky' Chen...</h2>
                         <br>
-                        <p class="lead">I am a backend software engineer with eight years shipping and operating production services, six of them in <a href="https://go.dev/">Go</a>. My depth is in distributed microservices, API design across REST, GraphQL, and gRPC, CI/CD automation, and cloud migration to AWS and Kubernetes. I own features end to end &mdash; design through production support &mdash; and I work comfortably across frontend, security, and business stakeholders.</p>
+                        <p class="lead">I am a backend software engineer with eight years building and running production software, six of them in <a href="https://go.dev/">Go</a>. My depth is in distributed microservices, API design across REST, GraphQL, and gRPC, CI/CD automation, and cloud migration to AWS and Kubernetes. I own features end to end &mdash; design through production support &mdash; and I work comfortably across frontend, security, and business stakeholders.</p>
 
                         <p class="lead">I came to this field the long way around, as a career changer with an M.S. in Computer Science earned at night while working full time. Most of my work lives in the parts of a system users never see: query layers, alerting pipelines, API contracts, build pipelines, and the debugging that keeps all of it honest. I have built for endpoint security forensics, oil and gas telemetry, and manufacturing floor hardware &mdash; domains where being wrong is expensive and the data does not wait for you.</p>
 
@@ -209,7 +209,7 @@
 
                 <div class="section-title">
                     <h2>Resume</h2>
-                    <p class="lead">Eight years shipping and operating production backend services, six of them in Go.</p>
+                    <p class="lead">Eight years building and running production backend software, six of them in Go.</p>
                 </div>
 
                 <div class="row gx-4 justify-content-center">
@@ -277,7 +277,7 @@
                             <h5>Jun 2018 &ndash; Dec 2018</h5>
                             <p><em><a href="https://towworks.com/">TowWorks</a> &mdash; Lake Jackson, TX</em></p>
                             <ul>
-                                <li>Built and shipped client-facing reporting tools serving 1,000+ paying customers</li>
+                                <li>Built and released client-facing reporting tools serving 1,000+ paying customers</li>
                                 <li>Used SQL and JSON parsing to drive a proprietary report generator</li>
                                 <li>Validated business-critical functionality for barge clients ahead of each release</li>
                                 <li>Led the redesign and implementation of the company homepage in Bootstrap</li>


### PR DESCRIPTION
Stacked on #7. **Merge #6 → #7 → this one**, in that order. GitHub retargets each base automatically as the one below it lands.

Two unrelated fixes, kept together because both came out of the same read-through of the live resume section.

## 1. Resume card spacing

The symptom was a leftover blue left border, oversized uppercase blue headings, and inflated list spacing.

**The cause was specificity, not padding values.** The base theme styles these with `.resume .resume-item h4` — two classes — which beats the single-class rules in `theme-modern.css` regardless of load order. The overrides were being written and silently losing.

| | Before | After |
| --- | --- | --- |
| Left edge | base theme's blue bar | hairline card border |
| `h4` | large, uppercase, blue | 1.02rem, sentence case, normal weight |
| `li` | base `padding-bottom` | normalised margins, no trailing gap |
| `.section-title` | stray bottom padding | tightened |
| First `.resume-title` | pushed the first card down | no top margin |

Only the properties that genuinely conflict are forced; everything else is left to normal cascade. There's a comment at the top of the file explaining why, so it doesn't read as carelessness later. The alternative was editing `styles.css` directly, which would have made the theme layer no longer cleanly removable.

## 2. "Shipping" → "building and running"

"Eight years shipping and operating production backend services" is ambiguous, and the page makes it worse: it sits a few lines above **barge clients** at TowWorks and **oil and gas telemetry** at NOV. A recruiter skimming has a real reason to file this under logistics rather than software.

Now: **"Eight years building and running production backend software."**

Same change in the About lead and the `meta description`. The TowWorks bullet reads "built and released" instead of "built and shipped".

The Japanese and Chinese profiles already said 開発・運用 and 開發與維運, which never carried the ambiguity — unchanged.

## Note on the history

The "Update branch" button on #7 landed a merge commit while this was being written, so the push came back non-fast-forward. I re-parented onto that merge rather than force-pushing over it; force would have discarded it silently. Nothing was lost.
