### PR TITLE
Community section: org logo and group photos

### DIFF
--- a/css/community.css
+++ b/css/community.css
@@ -1,0 +1,56 @@
+/*!
+ * community.css
+ * Org logo and group-photo styling for the Community Leadership section.
+ * Loaded after theme-modern.css.
+ */
+
+/* Logo sits inline with the role heading rather than as a photo-sized block.
+   object-fit: contain keeps a square mark square inside the circle, and the
+   white backing stops a transparent PNG from picking up the card colour. */
+.org-head {
+    display: flex;
+    align-items: center;
+    gap: .9rem;
+    margin-bottom: .6rem;
+}
+
+.org-logo {
+    flex: 0 0 58px;
+    width: 58px;
+    height: 58px;
+    border-radius: 50%;
+    object-fit: contain;
+    background: #fff;
+    border: 1px solid var(--c-border);
+    padding: 3px;
+}
+
+.org-head h4,
+.resume .org-head h4 { margin: 0 0 .25rem !important; }
+
+.org-head h5,
+.resume .org-head h5 { margin: 0 !important; }
+
+/* Group photo sits at the foot of the card, full bleed to the padding. */
+.org-photo {
+    margin: 1.1rem 0 0;
+}
+
+.org-photo img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 12px;
+    border: 1px solid var(--c-border);
+}
+
+.org-photo figcaption {
+    padding-top: .5rem;
+    font-size: .8rem;
+    color: var(--c-text-muted);
+}
+
+@media (max-width: 400px) {
+    .org-head { gap: .7rem; }
+    .org-logo { flex-basis: 46px; width: 46px; height: 46px; }
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         <link href="assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
         <!-- Modern cool-toned theme layer (loads last, overrides the base theme) -->
         <link href="css/theme-modern.css" rel="stylesheet">
+        <link href="css/community.css" rel="stylesheet">
 
     </head>
     <body id="page-top">
@@ -312,13 +313,22 @@
                     <div class="col-lg-5">
                         <h3 class="resume-title">Houston Nihongo Kai</h3>
                         <div class="resume-item">
-                            <h4>Founder &amp; Organizer</h4>
-                            <h5>Current</h5>
+                            <div class="org-head">
+                                <img class="org-logo" src="assets/community/hnk-logo.png" alt="Houston Nihongo Kai logo: Mount Fuji over a roundel split between the Texas and Japanese flags, lettered HNK" loading="lazy" width="1000" height="1000" />
+                                <div>
+                                    <h4>Founder &amp; Organizer</h4>
+                                    <h5>Current</h5>
+                                </div>
+                            </div>
                             <p><em>501(c)(3) nonprofit &mdash; <a href="https://nihongokai.org/">nihongokai.org</a> &middot; <a href="https://www.youtube.com/@nihongohtx">YouTube</a> &middot; <a href="mailto:cchen@nihongokai.org">cchen@nihongokai.org</a></em></p>
                             <ul>
                                 <li>Grew a casual language meetup into a registered 501(c)(3) with recurring programming: monthly socials, beginner Japanese grammar classes, English conversation (eikaiwa) for Japanese residents of Houston, university club collaborations, and group volunteering</li>
                                 <li>Secured funding and run ongoing operations, programming, and volunteer coordination</li>
                             </ul>
+                            <figure class="org-photo">
+                                <img src="assets/community/hnk-group.jpg" alt="Houston Nihongo Kai members gathered for a group photo at a monthly social" loading="lazy" width="1380" height="920" />
+                                <figcaption>Monthly social at Boba &amp; Broth, Sugar Land</figcaption>
+                            </figure>
                         </div>
                     </div>
 
@@ -335,10 +345,15 @@
 
                         <h3 class="resume-title">Taiwanese Junior Chamber of Commerce</h3>
                         <div class="resume-item">
-                            <h4>Volunteer &mdash; Houston Chapter</h4>
+                            <h4>Volunteer &mdash; Greater Houston Chapter</h4>
+                            <p><em>休士頓台灣青商會</em></p>
                             <ul>
                                 <li>Established and ran the organization's social presence (Instagram / Threads, Linktree), produced event flyers, and maintained the WordPress site</li>
                             </ul>
+                            <figure class="org-photo">
+                                <img src="assets/community/tjcc-group.jpg" alt="Members of the Taiwanese Junior Chamber of Commerce Greater Houston behind the chapter banner" loading="lazy" width="1280" height="960" />
+                                <figcaption>TJCC Greater Houston chapter</figcaption>
+                            </figure>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Rebased onto `master` now that `assets/community/` has landed. Clean two-file diff.

## What changed

**`index.html`**
- Houston Nihongo Kai card leads with the HNK logo inline beside the role heading
- HNK and TJCC cards each close with a captioned group photo
- Links `css/community.css`

**`css/community.css`** (new, 1.3 KB)
- `.org-head` — flex row for logo + heading
- `.org-logo` — 58px circular crop on a white plate, shrinks to 46px under a 400px viewport
- `.org-photo` — full-width rounded figure with a muted caption

Kept out of `theme-modern.css` so the theme layer stays revertible on its own.

## Assets

All three referenced images are on master and under the 500 KB `PHOTO_BUDGET_KB` limit:

| path | dimensions | size |
| --- | --- | --- |
| `assets/community/hnk-logo.png` | 256×256 | 31 KB |
| `assets/community/hnk-group.jpg` | 1200×800 | 163 KB |
| `assets/community/tjcc-group.jpg` | 1200×900 | 139 KB |

`assets/community/hnk-eikaiwa.jpg` is also on master but not referenced by this PR. `test_no_orphaned_photos` may emit an advisory notice about it — that check warns, it does not fail. Happy to wire it in as a second HNK photo.

## Note on faces

Both group photos show identifiable people. Worth confirming those members are fine appearing on a public portfolio site before merge.

---

⚠️ #10 was squash-merged, which is why this branch needed rebasing. Please use a **merge commit or rebase** here.